### PR TITLE
Fix The Fonts And The Mobile Background Paths

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -271,8 +271,8 @@ svg:not(:root) {
 
 @font-face {
   font-family: 'Minecraft';
-  src: url("/assets/fonts/minecraftfont.eot");
-  src: url("/assets/fonts/minecraftfont.woff") format("woff"), url("/assets/fonts/minecraftfont.ttf") format("truetype"); }
+  src: url("../fonts/minecraftfont.eot");
+  src: url("../fonts/minecraftfont.woff") format("woff"), url("../fonts/minecraftfont.ttf") format("truetype"); }
 
 #progress {
   position: absolute;
@@ -304,7 +304,7 @@ svg:not(:root) {
   height: 100%;
   text-align: center;
   z-index: 8;
-  background-image: url("/assets/textures/background.jpg");
+  background-image: url("../textures/background.jpg");
   background-size: cover;
   background-position: center; }
 
@@ -340,7 +340,7 @@ svg:not(:root) {
   height: 100%;
   text-align: center;
   z-index: 8;
-  background-image: url("/assets/textures/background.jpg");
+  background-image: url("../textures/background.jpg");
   background-size: cover;
   background-position: center; }
 


### PR DESCRIPTION
Fix the incorrect paths that blocked the fonts and the mobile background from rendering. For context, CSS on GitHub thinks the paths inside it are inside the directory the css files are located. For example, if your css file is in ```assets/css/style.css``` but you use ```assets/fonts/minecraftfont.woff```, it will look for ```assets/css/assets/fonts/minecraftfont.woff```, which i encountered while making my own open source fork of Minecraft Classic.
